### PR TITLE
fix typo in upgrade script - create upgrade script from v3.0 to v3.1

### DIFF
--- a/db upgrade/upgrade_unee-t_v2.19_to_v3.0.sql
+++ b/db upgrade/upgrade_unee-t_v2.19_to_v3.0.sql
@@ -35,12 +35,13 @@
 
 	DROP TABLE IF EXISTS `ut_db_schema_version`;
 
-	CREATE TABLE `ut_db_schema_version` (
-	  `id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Unique ID in this table',
-	  `schema_version` varchar(256) DEFAULT NULL COMMENT 'The current version of the BZ DB schema for Unee-T',
-	  `update_datetime` datetime DEFAULT NULL COMMENT 'Timestamp - when this version was implemented in THIS environment',
-	  `comment` text DEFAULT NULL COMMENT 'Comment'
-	) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+	CREATE TABLE `ut_db_schema_version`(
+		`id` INT(11) NOT NULL  AUTO_INCREMENT COMMENT 'Unique ID in this table' , 
+		`schema_version` VARCHAR(256) COLLATE utf8_general_ci NULL  COMMENT 'The current version of the BZ DB schema for Unee-T' , 
+		`update_datetime` DATETIME NULL  COMMENT 'Timestamp - when this version was implemented in THIS environment' , 
+		`comment` TEXT COLLATE utf8_general_ci NULL  COMMENT 'Comment' , 
+		PRIMARY KEY (`id`) 
+	) ENGINE=INNODB DEFAULT CHARSET='utf8' COLLATE='utf8_general_ci' ROW_FORMAT=DYNAMIC;
 	
 # We need to udpate the table 'ut_invitation_api_data' to make sure that the key 'mefe_invitation_id' is UNIQUE
 	/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
@@ -2164,7 +2165,7 @@ BEGIN
 		# Cleanup the variables for the log messages
 			SET @script_log_message = NULL;
 			SET @script = NULL;
-			SET @timestamp = NULL
+			SET @timestamp = NULL;
 			SET @bzfe_table = NULL;
 			SET @permission_granted = NULL;
 END IF ;

--- a/db upgrade/upgrade_unee-t_v3.0_to_v3.1.sql
+++ b/db upgrade/upgrade_unee-t_v3.0_to_v3.1.sql
@@ -1,0 +1,81 @@
+# For any question about this script, ask Franck
+#
+# This update adds constraints to make sure invitations can be processed correctly
+#
+############################################
+#
+# Make sure to update the below variable(s)
+#
+############################################
+#
+# What are the version of the Unee-T BZ Database schema BEFORE and AFTER this update?
+	SET @old_schema_version = 'v3.0';
+	SET @new_schema_version = 'v3.1';
+#
+###############################
+#
+# We have everything we need
+#
+###############################
+#
+#
+###################################################################################
+#
+# WARNING! It is recommended to use Amazon Aurora database engine for this version
+#
+###################################################################################
+
+# We make sure that for each invitation we want to create:
+#	- The invitor exists
+#	- The invitee exists
+#	- The product/unit exists
+#	- The bug/case exists
+
+/* Alter table in target */
+	ALTER TABLE `ut_invitation_api_data` 
+		ADD KEY `invitation_bz_bug_must_exist`(`bz_case_id`) , 
+		ADD KEY `invitation_bz_invitee_must_exist`(`bz_user_id`) , 
+		ADD KEY `invitation_bz_invitor_must_exist`(`bzfe_invitor_user_id`) , 
+		ADD KEY `invitation_bz_product_must_exist`(`bz_unit_id`) ;
+	ALTER TABLE `ut_invitation_api_data`
+		ADD CONSTRAINT `invitation_bz_bug_must_exist` 
+		FOREIGN KEY (`bz_case_id`) REFERENCES `bugs` (`bug_id`) , 
+		ADD CONSTRAINT `invitation_bz_invitee_must_exist` 
+		FOREIGN KEY (`bz_user_id`) REFERENCES `profiles` (`userid`) , 
+		ADD CONSTRAINT `invitation_bz_invitor_must_exist` 
+		FOREIGN KEY (`bzfe_invitor_user_id`) REFERENCES `profiles` (`userid`) , 
+		ADD CONSTRAINT `invitation_bz_product_must_exist` 
+		FOREIGN KEY (`bz_unit_id`) REFERENCES `products` (`id`) ;
+
+	  
+# We can now update the version of the database schema
+	# A comment for the update
+		SET @comment_update_schema_version = CONCAT (
+			'Database updated from '
+			, @old_schema_version
+			, ' to '
+			, @new_schema_version
+		)
+		;
+		
+	# Timestamp:
+		SET @timestamp = NOW();
+	
+	# Do the update
+	INSERT INTO `ut_db_schema_version`
+		(`id`
+		, `schema_version`
+		, `update_datetime`
+		, `comment`
+		)
+		VALUES
+		( 1
+		, @new_schema_version
+		, @timestamp
+		, @comment_update_schema_version
+		)
+		ON DUPLICATE KEY UPDATE
+		`schema_version` = @new_schema_version
+		, `update_datetime` = @timestamp
+		, `comment` = @comment_update_schema_version
+		;


### PR DESCRIPTION
This PR:
- Fixes typo in the script to upgrade from db schema v2.19 to v3.0
- Add constraints to the table 'ut_invitation_api_data' to make sure that
  - The invitor exists
  - The invitee exists
  - The product/unit exists
  - The case/bug exists
This will make the automated invitation process more robust